### PR TITLE
Очистка импортов, централизованная загрузка .env и валидация формата

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,7 @@
+# Development Log
+
+## 2025-08-09
+- Ran static analysis with `pyflakes` and removed unused imports.
+- Centralized `.env` loading in `config.py` and moved `HMAC_SECRET` there.
+- Added validation for `fmt` parameter in admin link generation route.
+- Expanded README with additional route examples.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ curl -sX POST http://localhost:8080/api/admin/link -H 'Content-Type: application
 ```
 3) Open returned `/sub/<uid>[.yaml|.json]`.
 
+## Route Examples
+
+- **Health check**
+  ```bash
+  curl http://localhost:8080/health
+  ```
+- **Revoke a UID**
+  ```bash
+  curl -sX POST http://localhost:8080/api/admin/revoke \
+       -H 'Content-Type: application/json' \
+       -d '{"uid":"<UUID>"}'
+  ```
+- **Retrieve subscription config**
+  ```bash
+  curl "http://localhost:8080/sub/<UID>?sig=<SIG>&exp=<EXP>"
+  curl "http://localhost:8080/sub/<UID>.yaml?sig=<SIG>&exp=<EXP>"
+  curl "http://localhost:8080/sub/<UID>.json?sig=<SIG>&exp=<EXP>"
+  ```
+
 ## Tests
 ```bash
 pip install -r requirements.txt

--- a/subscription_server/app/config.py
+++ b/subscription_server/app/config.py
@@ -9,6 +9,7 @@ DEFAULT_PBK = os.getenv("DEFAULT_PBK", "CHANGE_ME_PBK")
 DEFAULT_SID = os.getenv("DEFAULT_SID", "09c88c34c2a5fdb7")
 DEFAULT_FP = os.getenv("DEFAULT_FP", "chrome")
 LINK_TTL = int(os.getenv("LINK_TTL", "0"))
+HMAC_SECRET = os.getenv("HMAC_SECRET", "change_me_super_secret_key")
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 REDIS_CHANNEL = os.getenv("REDIS_CHANNEL", "uid_events")

--- a/subscription_server/app/database.py
+++ b/subscription_server/app/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy import text
 from .config import DB_DSN
 
 class Base(DeclarativeBase): pass

--- a/subscription_server/app/db_migrate.py
+++ b/subscription_server/app/db_migrate.py
@@ -1,4 +1,3 @@
-import asyncio, os
 from alembic import command
 from alembic.config import Config
 

--- a/subscription_server/app/routers/admin.py
+++ b/subscription_server/app/routers/admin.py
@@ -63,6 +63,9 @@ async def api_link(req: LinkReq):
     exp = now_ts() + exp_secs if exp_secs and exp_secs > 0 else 0
     payload = f"{req.uid}:{exp}"
     sig = sign(payload)
-    ext = "" if (not req.fmt or req.fmt == "txt") else (".yaml" if req.fmt == "yaml" else ".json")
+    if req.fmt not in (None, "txt", "yaml", "json"):
+        raise HTTPException(400, "Unsupported format")
+    ext_map = {"yaml": ".yaml", "json": ".json"}
+    ext = ext_map.get(req.fmt, "")
     url = f"/sub/{req.uid}{ext}?sig={sig}&exp={exp}"
     return {"url": url}

--- a/subscription_server/app/seed_uuids.py
+++ b/subscription_server/app/seed_uuids.py
@@ -1,5 +1,5 @@
 import argparse, asyncio, uuid
-from .database import get_engine, SessionLocal
+from .database import SessionLocal
 from .models import UID, UIDStatus
 
 async def seed(count: int):

--- a/subscription_server/app/utils/hmac_sig.py
+++ b/subscription_server/app/utils/hmac_sig.py
@@ -1,11 +1,8 @@
-import os, hmac, hashlib, time
-from dotenv import load_dotenv
-load_dotenv()
-
-SECRET = os.getenv("HMAC_SECRET", "change_me_super_secret_key")
+import hmac, hashlib, time
+from ..config import HMAC_SECRET
 
 def sign(payload: str) -> str:
-    return hmac.new(SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return hmac.new(HMAC_SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
 
 def verify(payload: str, sig: str) -> bool:
     expected = sign(payload)


### PR DESCRIPTION
## Summary
- удалены неиспользуемые импорты и добавлена централизованная загрузка `.env`
- добавлена проверка `fmt` в административном маршруте генерации ссылок
- расширена документация и добавлен файл `DEVLOG.md`

## Testing
- `pyflakes subscription_server/**/*.py`
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68978dae4af08332a6ed10392c9054fa